### PR TITLE
Bundle Lookup Matcher (Fix 17)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 				// c) "Main" means the define wrappers are removed, but content is untouched. Only for main* files.
 				onBuildWrite: function ( id, path, contents ) {
 					var name = id
-						.replace( /util\/|common\//, "" );
+						.replace( /util\/|common\/|var\//, "" );
 
 					if ( (/^EventEmitter$/).test( id ) ) {
 						contents = contents

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ See [How to get CLDR JSON data?](#how-to-get-cldr-json-data) below for more info
 var en = new Cldr( "en" );
 en.attributes;
 // {
-//   "languageId": "en",
+//   "bundle": "en",
+//   "minLanguageId": "en",
 //   "maxLanguageId": "en-Latn-US",
 //   "language": "en",
 //   "script": "Latn",
@@ -63,7 +64,8 @@ en.attributes;
 var zh = new Cldr( "zh-u-nu-finance-cu-cny" );
 zh.attributes;
 // {
-//   "languageId": "zh",
+//   "bundle": "zh-Hant",
+//   "minLanguageId": "zh",
 //   "maxLanguageId": "zh-Hans-CN",
 //   "language": "zh",
 //   "script": "Hans",
@@ -75,13 +77,13 @@ zh.attributes;
 
 ```
 
-- `language`, `script`, `territory` (also aliased as `region`), and `maxLanguageId` are computed by [adding likely subtags](./src/likely-subtags.js) according to the [specification](http://www.unicode.org/reports/tr35/#Likely_Subtags).
-- `languageId` is always in the succinct form, obtained by [removing the likely subtags from `maxLanguageId`](./src/remove-likely-subtags.js) according to the [specification](http://www.unicode.org/reports/tr35/#Likely_Subtags).
+- `language`, `script`, `territory` (also aliased as `region`), `maxLanguageId` (computed by [adding likely subtags](./src/core/likely_subtags.js)) and `minLanguageId` (computed by [removing likely subtags](./src/core/remove_likely_subtags.js)) according to the [specification](http://www.unicode.org/reports/tr35/#Likely_Subtags).
+- `bundle` holds the bundle lookup match based on the available loaded CLDR data, obtained by following [Bundle Lookup Matcher][].
 - [Unicode locale extensions](http://www.unicode.org/reports/tr35/#u_Extension).
 
 Comparison between different locales.
 
-| locale | languageId | maxLanguageId | language | script | region |
+| locale | minLanguageId | maxLanguageId | language | script | region |
 | --- | --- | --- | --- | --- | --- |
 | **en** |  `"en"` |  `"en-Latn-US"`  |  `"en"` |  `"Latn"` |  `"US"` |
 | **en-US** |  `"en"` |  `"en-Latn-US"`  |  `"en"` |  `"Latn"` |  `"US"` |
@@ -101,12 +103,12 @@ Comparison between different locales.
 en.main( "numbers/symbols-numberSystem-latn/decimal" );
 // ➡ "."
 // Equivalent to:
-// .get( "main/{languageId}/numbers/symbols-numberSystem-latn/decimal" );
+// .get( "main/{bundle}/numbers/symbols-numberSystem-latn/decimal" );
 
 ptBr.main( "numbers/symbols-numberSystem-latn/decimal" );
 // ➡ ","
 // Equivalent to:
-// .get( "main/{languageId}/numbers/symbols-numberSystem-latn/decimal" );
+// .get( "main/{bundle}/numbers/symbols-numberSystem-latn/decimal" );
 ```
 
 Have any [locale attributes](#cldrattributes) replaced with their corresponding values by embracing it with `{}`. In the example below, `{language}` is replaced with `"en"` and `{territory}` with `"US"`.
@@ -227,7 +229,7 @@ var ptBr = new Cldr( "pt-BR" );
 ptBr.main( "numbers/symbols-numberSystem-latn/decimal" );
 // ➡ ","
 // Equivalent to:
-// .get( "main/{languageId}/numbers/symbols-numberSystem-latn/decimal" );
+// .get( "main/{bundle}/numbers/symbols-numberSystem-latn/decimal" );
 ```
 
 We are UMD wrapped. So, it supports AMD, CommonJS, or global variables (in case neither AMD nor CommonJS have been detected).
@@ -368,7 +370,7 @@ You must also load any portion of the CLDR data you plan to use in your library 
 
 - **`.main( path )`**
 
- It's an alias for `.get([ "main/{languageId}", ... ])`.
+ It's an alias for `.get([ "main/{bundle}", ... ])`.
 
  [Read more...](doc/api/core/main.md)
 
@@ -458,7 +460,22 @@ You must also load any portion of the CLDR data you plan to use in your library 
 
  [Read more...](doc/api/unresolved/get.md)
 
-### Error reference
+## Error reference
+
+### CLDR Errors
+
+#### `E_MISSING_BUNDLE`
+
+Thrown when none of the loaded CLDR data can be used as a bundle for the corresponding locale. See more information on [Bundle Lookup Matcher][].
+
+Error object:
+
+| Attribute | Value |
+| --- | --- |
+| code | `E_MISSING_BUNDLE` |
+| locale | Locale whose bundle could not be found |
+
+### Parameter Errors
 
 #### `E_MISSING_PARAMETER`
 
@@ -500,6 +517,8 @@ Build distribution file.
 ```bash
 grunt
 ```
+
+[Bundle Lookup Matcher]: ./doc/bundle_lookup_matcher.md
 
 ## License
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cldrjs",
-  "version": "0.3.11",
+  "version": "0.4.0-pre",
   "dependencies": {
     "cldr-data": ">=25"
   },

--- a/doc/bundle_lookup_matcher.md
+++ b/doc/bundle_lookup_matcher.md
@@ -1,0 +1,133 @@
+## Bundle Lookup Matcher
+
+Bundle Lookup is the process of selecting the right dataset for the requested locale. We run this process during instance creation and set it on `instance.attributes.bundle`, which is further used when traversing items of the **main** dataset.
+
+User must load likelySubtags and any wanted main datasets prior to creating an instance. For example:
+
+```javascript
+Cldr.load(
+  cldr( "supplemental/likelySubtags" ),   // JSON data from supplemental/likelySubtags.json
+  cldr( "main/en-US/ca-gregorian" ),      // JSON data from main/en-US/ca-gregorian.json
+  cldr( "main/en-GB/ca-gregorian" )       // JSON data from main/en-GB/ca-gregorian.json
+);
+
+var enUs = new Cldr( "en-US" );
+console.log( enUs.attributes.bundle ); // "en-US"
+console.log( enUs.main( "dates/calendars/gregorian/dateFormats/short" ) ); // "M/d/yy"
+
+var enGb = new Cldr( "en-GB" );
+console.log( enGb.attributes.bundle ); // "en-GB"
+console.log( enGb.main( "dates/calendars/gregorian/dateFormats/short" ) ); // "dd/MM/y"
+```
+
+When instances are created, its `.attributes.bundle` reveals the matched bundle. The `.main` method uses this information to traverse the correct main item.
+
+What happens if we include `main/en/ca-gregorian` to the above example? 
+
+```javascript
+Cldr.load(
+  cldr( "supplemental/likelySubtags" ),   // JSON data from supplemental/likelySubtags.json
+  cldr( "main/en/ca-gregorian" ),         // JSON data from main/en/ca-gregorian.json
+  cldr( "main/en-US/ca-gregorian" ),      // JSON data from main/en-US/ca-gregorian.json
+  cldr( "main/en-GB/ca-gregorian" )       // JSON data from main/en-GB/ca-gregorian.json
+);
+
+var enUs = new Cldr( "en-US" ); // English as spoken in United States.
+console.log( enUs.attributes.bundle ); // "en"
+console.log( enUs.main( "dates/calendars/gregorian/dateFormats/short" ) ); // "M/d/yy"
+
+var enGb = new Cldr( "en-GB" ); // English as spoken in Great Britain.
+console.log( enGb.attributes.bundle ); // "en-GB"
+console.log( enGb.main( "dates/calendars/gregorian/dateFormats/short" ) ); // "dd/MM/y"
+```
+
+Now, the `en-US` requested locale uses the `en` bundle (not the `en-US` bundle as used in the first example) and `en-GB` still uses the `en-GB` bundle. Why? Because, `en` is the default content for `en-US` (deduced from likelySubtags data). Default content means that the child content is all in the parent. Therefore, both `en` and `en-US` are identical. Our bundle lookup matching algorithm always picks the grandest available parent. Note the retrieved main item is still the correct one (as it should be).
+
+A good observer may notice that loading both `main/en/ca-gregorian` and `main/en-US/ca-gregorian` is redundant. Although loading both is not a problem, loading either the `en` or the `en-US` bundle alone is enough.
+
+Let's add a bit of sugar to the requested locales.
+
+```javascript
+var en = new Cldr( "en" ); // English.
+console.log( en.attributes.bundle ); // "en"
+
+var enUs = new Cldr( "en-US" ); // English as spoken in United States.
+console.log( enUs.attributes.bundle ); // "en"
+
+var enLatnUs = new Cldr( "en-Latn-US" ); // English in Latin script as spoken in the United States.
+console.log( enLatnUs.attributes.bundle ); // "en"
+```
+
+All instances above obviously matches the same `en` bundle. Because, (a) `en` is the default content for `en-US` and (b) `en-US` is the default content for `en-Latn-US`.
+
+What happens if the requested locale includes unicode extensions?
+
+```javascript
+var en = new Cldr( "en-US-u-cu-USD" );
+console.log( en.attributes.bundle ); // "en"
+console.log( en.main( "numbers/currencies/{u-cu}/displayName" ) ); // "US Dollar"
+```
+
+Unicode extensions are obviously ignored on bundle lookup. Note they are accessible via variable replacements.
+
+Below are other non-obvious lookups.
+
+```javascript
+Cldr.load(
+  cldr( "supplemental/likelySubtags" ),   // JSON data from supplemental/likelySubtags.json
+  cldr( "main/sr-Cyrl/numbers" ),         // JSON data from main/sr-Cyrl/numbers.json
+  cldr( "main/sr-Latn/numbers" ),         // JSON data from main/sr-Latn/numbers.json
+  cldr( "main/zh-Hant/numbers" )          // JSON data from main/zh-Hant/numbers.json
+);
+
+var srCyrl = new Cldr( "sr-Cyrl" );
+console.log( srCyrl.attributes.bundle ); // "sr-Cyrl"
+console.log( srCyrl.main( "numbers/decimalFormats-numberSystem-latn/short/decimalFormat/1000-count-one" ) );
+// ➜ "0 хиљ'.'"
+
+var srRS = new Cldr( "sr-RS" );
+console.log( srRs.attributes.bundle ); // "sr-Cyrl"
+console.log( srRs.main( "numbers/decimalFormats-numberSystem-latn/short/decimalFormat/1000-count-one" ) );
+// ➜ "0 хиљ'.'"
+
+var srLatnRS = new Cldr( "sr-Latn-RS" );
+console.log( srLatnRS.attributes.bundle ); // "sr-Latn"
+console.log( srLatnRS.main( "numbers/decimalFormats-numberSystem-latn/short/decimalFormat/1000-count-one" ) );
+// ➜ "0 hilj'.'"
+
+var zhTW = new Cldr( "zh-TW" );
+console.log( zhTW.attributes.bundle ); // "zh-Hant"
+console.log( zhTW.main( "numbers/symbols-numberSystem-hanidec/nan" ) ); // "非數值"
+```
+
+Finally, if an instance is created whose bundle hasn't been loaded yet, its `.attributes.bundle` is set as `null`. If this instance is used to traverse a main dataset, an error is thrown. If this instance is used to traverse any non-main dataset (e.g., supplemental/postalCodeData.json) it can be used just fine.
+
+```javascript
+var zhCN = new Cldr( "zh-CN" );
+console.log( zhCN.attributes.bundle ); // null
+console.log( zhCN.main( /* something */ ) ); // Error: E_MISSING_BUNDLE
+```
+
+### Implementation details
+
+[UTS#35][] doesn't specify how bundle lookup matcher should be implemented. [RFC 4647][] section 3.4 "Lookup" has an algorithm for that, although it fails in various cases listed above. Mark Davis, the co-founder and president of the Unicode Consortium, said (via CLDR mailing list and via [Fixing Inheritance doc][]) that bundle lookup should happen via [LanguageMatching](http://www.unicode.org/reports/tr35/#LanguageMatching).
+
+Our belief is that LanguageMatching is a great algorithm for Best Fit Matcher. Although, it's an overkill for Lookup Matcher.
+
+ICU (a known CLDR implementation) doesn't use LanguageMatching for Bundle Lookup Matcher either. But, it has its own implementation, which has its own flaws as Mark Davis says in the Fixing Inheritance doc "ICU uses the %%ALIAS element to counteract some of these problems... It doesn’t fix all of them, and the data is not derivable from CLDR."
+
+We also believe ICU's aliases approach is not the best solution. Instead we believe in the following approach, whose result matches LanguageMatching with a score threshold of 100%.
+
+`BundleLookupMatcher( requestedLocale, availableBundles )` is used for bundle lookup given an arbitrary `requestedLocale`.
+
+  1. Create a Hash (aka Dictionary or Key-Value-Pair) object, named `availableBundlesMap`, that maps each `availableBundle` (value) to its respective [Remove Likely Subtags][] result (key).
+    1. In case of a duplicate key, keep the smaller value, i.e., keep the available bundle locale whose length is the smallest; e.g., keep { "en": "en" } instead of { "en": "en-US" }.
+  1. [Remove Likely Subtags][] from `requestedLocale` and let `minRequestedLocale` keep its result.
+  1. Return `availableBundlesMap[ minRequestedLocale ]`.
+
+This algorithm is faster than LanguageMatching and needs no extra CLDR to be created and maintained (likelySubtags is sufficient). Note the `availableBundlesMap` can be cached for improved performance on repeated calls.
+
+[Fixing Inheritance doc]: https://docs.google.com/document/d/1qZwEVb4kfODi2TK5f4x15FYWj5rJRijXmSIg5m6OH8s/edit
+[Remove Likely Subtags]: http://www.unicode.org/reports/tr35/tr35.html#Likely_Subtags
+[RFC 4647]: http://www.ietf.org/rfc/rfc4647.txt
+[UTS#35]: http://www.unicode.org/reports/tr35

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cldrjs",
-  "version": "0.3.11",
+  "version": "0.4.0-pre",
   "description": "Simple CLDR API",
   "keywords": [
     "utility",

--- a/src/build/intro_unresolved.js
+++ b/src/build/intro_unresolved.js
@@ -28,11 +28,10 @@
 }(function( Cldr ) {
 
 	// Build optimization hack to avoid duplicating functions across modules.
-	var alwaysArray = Cldr._alwaysArray;
+	var coreLoad = Cldr._coreLoad;
 	var jsonMerge = Cldr._jsonMerge;
 	var pathNormalize = Cldr._pathNormalize;
 	var resourceGet = Cldr._resourceGet;
 	var validatePresence = Cldr._validatePresence;
 	var validateTypePath = Cldr._validateTypePath;
-	var validateTypePlainObject = Cldr._validateTypePlainObject;
 

--- a/src/bundle/lookup.js
+++ b/src/bundle/lookup.js
@@ -1,0 +1,40 @@
+define([
+	"../core/likely_subtags",
+	"../core/remove_likely_subtags",
+	"../core/subtags",
+	"../util/array/for_each"
+], function( coreLikelySubtags, coreRemoveLikelySubtags, coreSubtags, arrayForEach ) {
+
+	/**
+	 * bundleLookup( minLanguageId )
+	 *
+	 * @Cldr [Cldr class]
+	 *
+	 * @cldr [Cldr instance]
+	 *
+	 * @minLanguageId [String] requested languageId after applied remove likely subtags.
+	 */
+	return function( Cldr, cldr, minLanguageId ) {
+		var availableBundleMap = Cldr._availableBundleMap,
+			availableBundleMapQueue = Cldr._availableBundleMapQueue;
+
+		if ( availableBundleMapQueue.length ) {
+			arrayForEach( availableBundleMapQueue, function( bundle ) {
+				var existing, maxBundle, minBundle, subtags;
+				subtags = coreSubtags( bundle );
+				maxBundle = coreLikelySubtags( Cldr, cldr, subtags, { force: true } ) || subtags;
+				minBundle = coreRemoveLikelySubtags( Cldr, cldr, maxBundle );
+				minBundle = minBundle.join( Cldr.localeSep );
+				existing = availableBundleMapQueue[ minBundle ];
+				if ( existing && existing.length < bundle.length ) {
+					return;
+				}
+				availableBundleMap[ minBundle ] = bundle;
+			});
+			Cldr._availableBundleMapQueue = [];
+		}
+
+		return availableBundleMap[ minLanguageId ] || null;
+	};
+
+});

--- a/src/core/load.js
+++ b/src/core/load.js
@@ -1,0 +1,38 @@
+define([
+	"./set_available_bundles",
+	"../common/validate/presence",
+	"../common/validate/type/plain_object",
+	"../util/always_array",
+	"../util/json/merge"
+], function( coreSetAvailableBundles, validatePresence, validateTypePlainObject, alwaysArray, jsonMerge ) {
+
+	/**
+	 * load( Cldr, source, jsons )
+	 *
+	 * @Cldr [Cldr class]
+	 *
+	 * @source [Object]
+	 *
+	 * @jsons [arguments]
+	 */
+	return function( Cldr, source, jsons ) {
+		var i, j, json;
+
+		validatePresence( jsons[ 0 ], "json" );
+
+		// Support arbitrary parameters, e.g., `Cldr.load({...}, {...})`.
+		for ( i = 0; i < jsons.length; i++ ) {
+
+			// Support array parameters, e.g., `Cldr.load([{...}, {...}])`.
+			json = alwaysArray( jsons[ i ] );
+
+			for ( j = 0; j < json.length; j++ ) {
+				validateTypePlainObject( json[ j ], "json" );
+				source = jsonMerge( source, json[ j ] );
+				coreSetAvailableBundles( Cldr, json[ j ] );
+			}
+		}
+
+		return source;
+	};
+});

--- a/src/core/set_available_bundles.js
+++ b/src/core/set_available_bundles.js
@@ -1,0 +1,27 @@
+define([
+	"../resource/get"
+], function( resourceGet ) {
+
+	/**
+	 * setAvailableBundles( Cldr, json )
+	 *
+	 * @Cldr [Cldr class]
+	 *
+	 * @json resolved/unresolved cldr data.
+	 *
+	 * Set available bundles queue based on passed json CLDR data. Considers a bundle as any String at /main/{bundle}.
+	 */
+	return function( Cldr, json ) {
+		var bundle,
+			availableBundleMapQueue = Cldr._availableBundleMapQueue,
+			main = resourceGet( json, [ "main" ] );
+
+		if ( main ) {
+			for ( bundle in main ) {
+				if ( main.hasOwnProperty( bundle ) ) {
+					availableBundleMapQueue.push( bundle );
+				}
+			}
+		}
+	};
+});

--- a/src/core/subtags.js
+++ b/src/core/subtags.js
@@ -1,0 +1,50 @@
+define(function() {
+
+	/**
+	 * subtags( locale )
+	 *
+	 * @locale [String]
+	 */
+	return function( locale ) {
+		var aux, unicodeLanguageId,
+			subtags = [];
+
+		locale = locale.replace( /_/, "-" );
+
+		// Unicode locale extensions.
+		aux = locale.split( "-u-" );
+		if ( aux[ 1 ] ) {
+			aux[ 1 ] = aux[ 1 ].split( "-t-" );
+			locale = aux[ 0 ] + ( aux[ 1 ][ 1 ] ? "-t-" + aux[ 1 ][ 1 ] : "");
+			subtags[ 4 /* unicodeLocaleExtensions */ ] = aux[ 1 ][ 0 ];
+		}
+
+		// TODO normalize transformed extensions. Currently, skipped.
+		// subtags[ x ] = locale.split( "-t-" )[ 1 ];
+		unicodeLanguageId = locale.split( "-t-" )[ 0 ];
+
+		// unicode_language_id = "root"
+		//   | unicode_language_subtag         
+		//     (sep unicode_script_subtag)? 
+		//     (sep unicode_region_subtag)?
+		//     (sep unicode_variant_subtag)* ;
+		//
+		// Although unicode_language_subtag = alpha{2,8}, I'm using alpha{2,3}. Because, there's no language on CLDR lengthier than 3.
+		aux = unicodeLanguageId.match( /^(([a-z]{2,3})(-([A-Z][a-z]{3}))?(-([A-Z]{2}|[0-9]{3}))?)(-[a-zA-Z0-9]{5,8}|[0-9][a-zA-Z0-9]{3})*$|^(root)$/ );
+		if ( aux === null ) {
+			return [ "und", "Zzzz", "ZZ" ];
+		}
+		subtags[ 0 /* language */ ] = aux[ 9 ] /* root */ || aux[ 2 ] || "und";
+		subtags[ 1 /* script */ ] = aux[ 4 ] || "Zzzz";
+		subtags[ 2 /* territory */ ] = aux[ 6 ] || "ZZ";
+		subtags[ 3 /* variant */ ] = aux[ 7 ];
+
+		// 0: language
+		// 1: script
+		// 2: territory (aka region)
+		// 3: variant
+		// 4: unicodeLocaleExtensions
+		return subtags;
+	};
+
+});

--- a/src/item/lookup.js
+++ b/src/item/lookup.js
@@ -34,7 +34,7 @@ define([
 		if ( !value ) {
 			// Or, lookup at parent locale
 			parent = bundleParentLookup( Cldr, locale );
-			value = lookup( Cldr, parent, path, jsonMerge( attributes, { languageId: parent }), locale );
+			value = lookup( Cldr, parent, path, jsonMerge( attributes, { bundle: parent }), locale );
 		}
 
 		if ( value ) {

--- a/src/unresolved.js
+++ b/src/unresolved.js
@@ -1,37 +1,23 @@
 define([
 	"./common/validate/presence",
 	"./common/validate/type/path",
-	"./common/validate/type/plain_object",
 	"./core",
-	"./item/lookup",
-	"./util/always_array",
-	"./util/json/merge"
-], function( validatePresence, validateTypePath, validateTypePlainObject, Cldr, itemLookup, alwaysArray, jsonMerge ) {
+	"./core/load",
+	"./item/lookup"
+], function( validatePresence, validateTypePath, Cldr, coreLoad, itemLookup ) {
 
 	Cldr._raw = {};
 
 	/**
-	 * Load resolved or unresolved cldr data
-	 * @json [JSON]
-	 *                                       
+	 * Cldr.load( json [, json, ...] )
+	 *
+	 * @json [JSON] CLDR data or [Array] Array of @json's.
+	 *
+	 * Load resolved or unresolved cldr data.
 	 * Overwrite Cldr.load().
 	 */
-	Cldr.load = function( json ) {
-		var i, j;
-
-		validatePresence( json, "json" );
-
-		// Support arbitrary parameters, e.g., `Cldr.load({...}, {...})`.
-		for ( i = 0; i < arguments.length; i++ ) {
-
-			// Support array parameters, e.g., `Cldr.load([{...}, {...}])`.
-			json = alwaysArray( arguments[ i ] );
-
-			for ( j = 0; j < json.length; j++ ) {
-				validateTypePlainObject( json[ j ], "json" );
-				Cldr._raw = jsonMerge( Cldr._raw, json[ j ] );
-			}
-		}
+	Cldr.load = function() {
+		Cldr._raw = coreLoad( Cldr, Cldr._raw, arguments );
 	};
 
 	/**
@@ -41,9 +27,9 @@ define([
 		validatePresence( path, "path" );
 		validateTypePath( path, "path" );
 
-		// 1: use languageId as locale on item lookup for simplification purposes, because no other extended subtag is used anyway on bundle parent lookup.
-		// 2: during init(), this method is called, but languageId is yet not defined. Use "" as a workaround in this very specific scenario.
-		return itemLookup( Cldr, this.attributes && this.attributes.languageId /* 1 */ || "" /* 2 */, path, this.attributes );
+		// 1: use bundle as locale on item lookup for simplification purposes, because no other extended subtag is used anyway on bundle parent lookup.
+		// 2: during init(), this method is called, but bundle is yet not defined. Use "" as a workaround in this very specific scenario.
+		return itemLookup( Cldr, this.attributes && this.attributes.bundle !== null /* 1 */ || "" /* 2 */, path, this.attributes );
 	};
 
 	// In case cldr/unresolved is loaded after cldr/event, we trigger its overloads again. Because, .get is overwritten in here.

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -13,5 +13,5 @@
 	"undef": true,
 	"unused": true,
 
-	"predef": [ "define", "describe", "expect", "it", "mocha", "require", "setTimeout" ]
+	"predef": [ "after", "before", "define", "describe", "expect", "it", "mocha", "require", "setTimeout" ]
 }

--- a/test/functional/core.js
+++ b/test/functional/core.js
@@ -96,6 +96,14 @@ define([
 			});
 		});
 
+		it( "should throw error on missing bundle", function() {
+			var cldr = new Cldr( "sr-RS" );
+			expect( cldr.attributes.bundle ).to.be.null;
+			expect(function() {
+				cldr.main( "numbers" );
+			}).to.throw( Error, /E_MISSING_BUNDLE/ );
+		});
+
 	});
 
 });

--- a/test/unit.js
+++ b/test/unit.js
@@ -16,10 +16,17 @@ require([
 	"./unit/path/normalize",
 
 	// 2nd unit tests group.
+	"./unit/core/load",
+	"./unit/core/set_available_bundles",
+
+	// 3rd unit tests group.
 	"./unit/core",
 	"./unit/core/likely_subtags",
 	"./unit/core/remove_likely_subtags",
-	"./unit/supplemental"
+	"./unit/supplemental",
+
+	// 4th unit tests group.
+	"./unit/bundle/lookup"
 
 ], function() {
 	mocha.run();

--- a/test/unit/bundle/lookup.js
+++ b/test/unit/bundle/lookup.js
@@ -1,0 +1,59 @@
+define([
+	"src/bundle/lookup",
+	"src/core",
+	"json!cldr-data/supplemental/likelySubtags.json"
+], function( bundleLookup, Cldr, likelySubtags ) {
+
+	describe( "Bundle Lookup", function() {
+
+		before(function() {
+			Cldr.load( likelySubtags );
+		});
+
+		// This test must pass to ensure this whole unit test run under the planned premises.
+		it( "should pass test's prerequisites", function() {
+			expect( Cldr._availableBundleMapQueue ).to.not.include.members([ "sr", "sr-Cyrl", "sr-Latn" ]);
+			expect( Cldr._availableBundleMap ).to.not.contain.keys( "sr", "sr-Latn" );
+		});
+
+		it( "should set the correct bundle", function() {
+			var sr;
+			Cldr.load({
+				main: { "sr-Cyrl": {} }
+			});
+			expect( Cldr._availableBundleMapQueue ).to.include.members([ "sr-Cyrl" ]);
+			sr = new Cldr( "sr" );
+			expect( Cldr._availableBundleMapQueue ).to.eql([]);
+			expect( Cldr._availableBundleMap ).to.contain.keys( "sr" );
+			expect( Cldr._availableBundleMap.sr ).to.equal( "sr-Cyrl" );
+			expect( sr.attributes.bundle ).to.equal( "sr-Cyrl" );
+			sr = new Cldr( "sr-Cyrl" );
+			expect( sr.attributes.bundle ).to.equal( "sr-Cyrl" );
+			sr = new Cldr( "sr-RS" );
+			expect( sr.attributes.bundle ).to.equal( "sr-Cyrl" );
+			sr = new Cldr( "sr-Cyrl-RS" );
+			expect( sr.attributes.bundle ).to.equal( "sr-Cyrl" );
+			sr = new Cldr( "sr-Latn-RS" );
+			expect( sr.attributes.bundle ).to.be.null;
+		});
+
+		it( "should always favor the grandest parent", function() {
+			var sr;
+			Cldr.load({
+				main: { "sr": {} }
+			});
+			expect( Cldr._availableBundleMapQueue ).to.include.members([ "sr" ]);
+			sr = new Cldr( "sr" );
+			expect( Cldr._availableBundleMapQueue ).to.eql([]);
+			expect( Cldr._availableBundleMap ).to.contain.keys( "sr" );
+			expect( Cldr._availableBundleMap.sr ).to.equal( "sr" );
+			expect( sr.attributes.bundle ).to.equal( "sr" );
+			sr = new Cldr( "sr-Cyrl" );
+			expect( sr.attributes.bundle ).to.equal( "sr" );
+			sr = new Cldr( "sr-RS" );
+			expect( sr.attributes.bundle ).to.equal( "sr" );
+		});
+
+	});
+
+});

--- a/test/unit/bundle/parent_lookup.js
+++ b/test/unit/bundle/parent_lookup.js
@@ -4,9 +4,11 @@ define([
 	"json!cldr-data/supplemental/parentLocales.json"
 ], function( Cldr, parentLookup, parentLocalesJson ) {
 
-	Cldr.load( parentLocalesJson );
-
 	describe( "Bundle Parent Lookup", function() {
+
+		before(function() {
+			Cldr.load( parentLocalesJson );
+		});
 
 		it( "should truncate locale", function() {
 			expect( parentLookup( Cldr, [ "pt", "BR" ].join( Cldr.localeSep ) ) ).to.equal( "pt" );

--- a/test/unit/core.js
+++ b/test/unit/core.js
@@ -4,58 +4,71 @@ define([
 	"json!cldr-data/supplemental/likelySubtags.json"
 ], function( Cldr, enNumbersJson, likelySubtagsJson ) {
 
-	Cldr.load( enNumbersJson, likelySubtagsJson );
-
 	describe( "Cldr (core)", function() {
-		var cldr;
-
-		it( "should normalize a locale on initialization", function() {
-			cldr = new Cldr( "pt-BR" );
-			expect( cldr.attributes.language ).to.equal( "pt" );
-			expect( cldr.attributes.script ).to.equal( "Latn" );
-			expect( cldr.attributes.territory ).to.equal( "BR" );
-
-			cldr = new Cldr( "en" );
-			expect( cldr.attributes.language ).to.equal( "en" );
-			expect( cldr.attributes.script ).to.equal( "Latn" );
-			expect( cldr.attributes.territory ).to.equal( "US" );
-
-			cldr = new Cldr( "en-GB" );
-			expect( cldr.attributes.language ).to.equal( "en" );
-			expect( cldr.attributes.script ).to.equal( "Latn" );
-			expect( cldr.attributes.territory ).to.equal( "GB" );
-
-			cldr = new Cldr( "lkt" );
-			expect( cldr.attributes.language ).to.equal( "lkt" );
-			expect( cldr.attributes.script ).to.equal( "Latn" );
-			expect( cldr.attributes.territory ).to.equal( "US" );
-
-			cldr = new Cldr( "root" );
-			expect( cldr.attributes.language ).to.equal( "en" );
-			expect( cldr.attributes.script ).to.equal( "Latn" );
-			expect( cldr.attributes.territory ).to.equal( "US" );
-
-			// Should not identify nonExistent as a language subtag, due to its length. So, it should become `und_Zzzz_ZZ`. Then, the `und` likelySubtags value.
-			cldr = new Cldr( "nonExistent" );
-			expect( cldr.attributes.language ).to.equal( "en" );
-			expect( cldr.attributes.script ).to.equal( "Latn" );
-			expect( cldr.attributes.territory ).to.equal( "US" );
+		before(function() {
+			Cldr.load( enNumbersJson, likelySubtagsJson );
 		});
 
-		it( "should set unicode locale extensions attributes", function() {
-			cldr = new Cldr( "en-u-cu-usd" );
-			expect( cldr.attributes[ "u-cu" ] ).to.equal( "usd" );
+		describe( "Cldr.load()", function() {
 
-			cldr = new Cldr( "en-u-foo-bar-nu-arab-cu-usd" );
-			expect( cldr.attributes[ "u-foo" ] ).to.be.true;
-			expect( cldr.attributes[ "u-bar" ] ).to.be.true;
-			expect( cldr.attributes[ "u-cu" ] ).to.equal( "usd" );
-			expect( cldr.attributes[ "u-nu" ] ).to.equal( "arab" );
+			it( "should load json", function() {
+				expect( Cldr._resolved && Cldr._resolved.supplemental ).to.be.ok;
+			});
+
 		});
 
-		it( "should implement cldr.main as an alias of get( \"main/{languageId}...\" )", function() {
-			cldr = new Cldr( "en" );
-			expect( cldr.main( "numbers/symbols-numberSystem-latn/decimal" ) ).to.equal( "." );
+		describe( "Constructor", function() {
+			var cldr;
+
+			it( "should normalize a locale on initialization", function() {
+				cldr = new Cldr( "pt-BR" );
+				expect( cldr.attributes.language ).to.equal( "pt" );
+				expect( cldr.attributes.script ).to.equal( "Latn" );
+				expect( cldr.attributes.territory ).to.equal( "BR" );
+
+				cldr = new Cldr( "en" );
+				expect( cldr.attributes.language ).to.equal( "en" );
+				expect( cldr.attributes.script ).to.equal( "Latn" );
+				expect( cldr.attributes.territory ).to.equal( "US" );
+
+				cldr = new Cldr( "en-GB" );
+				expect( cldr.attributes.language ).to.equal( "en" );
+				expect( cldr.attributes.script ).to.equal( "Latn" );
+				expect( cldr.attributes.territory ).to.equal( "GB" );
+
+				cldr = new Cldr( "lkt" );
+				expect( cldr.attributes.language ).to.equal( "lkt" );
+				expect( cldr.attributes.script ).to.equal( "Latn" );
+				expect( cldr.attributes.territory ).to.equal( "US" );
+
+				cldr = new Cldr( "root" );
+				expect( cldr.attributes.language ).to.equal( "en" );
+				expect( cldr.attributes.script ).to.equal( "Latn" );
+				expect( cldr.attributes.territory ).to.equal( "US" );
+
+				// Should not identify nonExistent as a language subtag, due to its length. So, it should become `und_Zzzz_ZZ`. Then, the `und` likelySubtags value.
+				cldr = new Cldr( "nonExistent" );
+				expect( cldr.attributes.language ).to.equal( "en" );
+				expect( cldr.attributes.script ).to.equal( "Latn" );
+				expect( cldr.attributes.territory ).to.equal( "US" );
+			});
+
+			it( "should set unicode locale extensions attributes", function() {
+				cldr = new Cldr( "en-u-cu-usd" );
+				expect( cldr.attributes[ "u-cu" ] ).to.equal( "usd" );
+
+				cldr = new Cldr( "en-u-foo-bar-nu-arab-cu-usd" );
+				expect( cldr.attributes[ "u-foo" ] ).to.be.true;
+				expect( cldr.attributes[ "u-bar" ] ).to.be.true;
+				expect( cldr.attributes[ "u-cu" ] ).to.equal( "usd" );
+				expect( cldr.attributes[ "u-nu" ] ).to.equal( "arab" );
+			});
+
+			it( "should implement cldr.main as an alias of get( \"main/{bundle}...\" )", function() {
+				cldr = new Cldr( "en" );
+				expect( cldr.main( "numbers/symbols-numberSystem-latn/decimal" ) ).to.equal( "." );
+			});
+
 		});
 
 	});

--- a/test/unit/core/likely_subtags.js
+++ b/test/unit/core/likely_subtags.js
@@ -4,10 +4,12 @@ define([
 	"json!cldr-data/supplemental/likelySubtags.json"
 ], function( Cldr, likelySubtags, likelySubtagsJson ) {
 
-	Cldr.load( likelySubtagsJson );
-
 	describe( "Likely Subtags", function() {
 		var cldr = new Cldr( "root" );
+
+		before(function() {
+			Cldr.load( likelySubtagsJson );
+		});
 
 		it( "should skip empty language tag", function() {
 			expect( likelySubtags( Cldr, cldr, [ "en", "Latn", "US" ] ) ).to.eql( [ "en", "Latn", "US" ] );

--- a/test/unit/core/load.js
+++ b/test/unit/core/load.js
@@ -1,0 +1,31 @@
+define([
+	"src/core/load"
+], function( _load ) {
+
+	describe( "Core load", function() {
+		var fakeCldr = {
+			_availableBundleMapQueue: []
+		};
+
+		function load() {
+			return _load( fakeCldr, {}, arguments );
+		}
+
+		it( "should load a json entry", function() {
+			var source = load({ foo: "bar" });
+			expect( source ).to.eql({ foo: "bar" });
+		});
+
+		it( "should load arbitrary json parameters, e.g., Cldr.load({...}, {...}, ...)", function() {
+			var source = load({ foo: "bar" }, { baz: "qux" });
+			expect( source ).to.eql({ baz: "qux", foo: "bar" });
+		});
+
+		it( "should load arbitrary jsons via Array, e.g., Cldr.load([{...}, {...}, ...])", function() {
+			var source = load([{ foo: "bar" }, { baz: "qux" }]);
+			expect( source ).to.eql({ baz: "qux", foo: "bar" });
+		});
+
+	});
+
+});

--- a/test/unit/core/remove_likely_subtags.js
+++ b/test/unit/core/remove_likely_subtags.js
@@ -4,11 +4,12 @@ define([
 	"json!cldr-data/supplemental/likelySubtags.json"
 ], function( Cldr, removeLikelySubtags, likelySubtagsJson ) {
 
-	Cldr.load( likelySubtagsJson );
-
 	describe( "Remove Likely Subtags", function() {
-
 		var cldr = new Cldr( "root" );
+
+		before(function() {
+			Cldr.load( likelySubtagsJson );
+		});
 
 		it( "Should reduce \"en_Latn_US\" into \"en\"", function() {
 			expect( removeLikelySubtags( Cldr, cldr, [ "en", "Latn", "US" ] ) ).to.eql( [ "en" ] );

--- a/test/unit/core/set_available_bundles.js
+++ b/test/unit/core/set_available_bundles.js
@@ -1,0 +1,24 @@
+define([
+	"src/core/set_available_bundles"
+], function( setAvailableBundles ) {
+
+	describe( "Core setAvailableBundles", function() {
+		var fakeCldr = {
+			_availableBundleMap: {},
+			_availableBundleMapQueue: []
+		};
+
+		it( "should set availableBundleMapQueue", function() {
+			setAvailableBundles( fakeCldr, {
+				main: { "en-US": {} }
+			});
+			expect( fakeCldr._availableBundleMapQueue ).to.eql([ "en-US" ]);
+			setAvailableBundles( fakeCldr, {
+				main: { "pt-BR": {} }
+			});
+			expect( fakeCldr._availableBundleMapQueue ).to.eql([ "en-US", "pt-BR" ]);
+		});
+
+	});
+
+});

--- a/test/unit/item/lookup.js
+++ b/test/unit/item/lookup.js
@@ -7,19 +7,21 @@ define([
 	"src/unresolved"
 ], function( Cldr, itemLookup, ptNumbersJson, genderJson, likelySubtagsJson ) {
 
-	Cldr.load(
-		genderJson,
-		likelySubtagsJson,
-		ptNumbersJson,
-		{
-			"lookup-test": {
-				a: 1,
-				b: 2
-			}
-		}
-	);
-
 	describe( "Item Lookup", function() {
+
+		before(function() {
+			Cldr.load(
+				genderJson,
+				likelySubtagsJson,
+				ptNumbersJson,
+				{
+					"lookup-test": {
+						a: 1,
+						b: 2
+					}
+				}
+			);
+		});
 
 		it( "should get resolved items", function() {
 			var cldr = new Cldr( "root" );
@@ -28,7 +30,7 @@ define([
 
 		it( "should resolve and get unresolved items", function() {
 			var cldr = new Cldr( "pt_BR" );
-			expect( itemLookup( Cldr, cldr.locale, "/main/{languageId}/numbers/symbols-numberSystem-latn/decimal", cldr.attributes ) ).to.equal( "," );
+			expect( itemLookup( Cldr, cldr.locale, "/main/{bundle}/numbers/symbols-numberSystem-latn/decimal", cldr.attributes ) ).to.equal( "," );
 		});
 
 		it( "should only cache found resolved items", function() {

--- a/test/unit/supplemental.js
+++ b/test/unit/supplemental.js
@@ -6,24 +6,28 @@ define([
 	"json!cldr-data/supplemental/weekData.json"
 ], function( Cldr, supplemental, likelySubtagsJson, timeDataJson, weekDataJson ) {
 
-	Cldr.load(
-		likelySubtagsJson,
-		timeDataJson,
-		weekDataJson
-	);
-
 	describe( "Supplemental", function() {
-		var en = new Cldr( "en" ),
+		var en, enGb, fr, ptBr, ty;
+
+		before(function() {
+			Cldr.load(
+				likelySubtagsJson,
+				timeDataJson,
+				weekDataJson
+			);
+
+			en = new Cldr( "en" ),
 			enGb = new Cldr( "en_GB" ),
 			fr = new Cldr( "fr" ),
 			ptBr = new Cldr( "pt_BR" ),
 			ty = new Cldr( "ty" );
 
-		en.supplemental = supplemental( en );
-		enGb.supplemental = supplemental( enGb );
-		fr.supplemental = supplemental( fr );
-		ptBr.supplemental = supplemental( ptBr );
-		ty.supplemental = supplemental( ty );
+			en.supplemental = supplemental( en );
+			enGb.supplemental = supplemental( enGb );
+			fr.supplemental = supplemental( fr );
+			ptBr.supplemental = supplemental( ptBr );
+			ty.supplemental = supplemental( ty );
+		});
 
 		it( "should get weekData.firstDay", function() {
 			// Explicitly defined firstDay.


### PR DESCRIPTION
Create bundle lookup matcher and use {bundle} (instead of {languageId}) to traverse main items.
    
Fixes #17