### PR TITLE
Fix "example" typo in the documentation.

### DIFF
--- a/doc/api/core/constructor.md
+++ b/doc/api/core/constructor.md
@@ -2,7 +2,7 @@
 
 Create a new instance of Cldr.
 
-| Parameter | Type | Exampe |
+| Parameter | Type | Example |
 | --- | --- | --- |
 | *locale* | String | `"en"`, `"pt-BR"` |
 

--- a/doc/api/core/get.md
+++ b/doc/api/core/get.md
@@ -2,7 +2,7 @@
 
 Get the item data given its path, or `undefined` if missing.
 
-| Parameter | Type | Exampe |
+| Parameter | Type | Example |
 | --- | --- | --- |
 | *path* | String or<br>Array | `"/cldr/main/{languageId}/numbers/symbols-numberSystem-latn/decimal"`<br>`[ "cldr", "main", "{languageId}", "numbers", "symbols-numberSystem-latn", "decimal" ]` |
 

--- a/doc/api/core/main.md
+++ b/doc/api/core/main.md
@@ -2,7 +2,7 @@
 
 It's an alias for `.get([ "main/{languageId}", ... ])`.
 
-| Parameter | Type | Exampe |
+| Parameter | Type | Example |
 | --- | --- | --- |
 | *path* | String or<br>Array | See `cldr.get()` for more information |
 

--- a/doc/api/event/global_off.md
+++ b/doc/api/event/global_off.md
@@ -2,7 +2,7 @@
 
 Removes a listener function from the specified event globally (for all instances).
 
-| Parameter | Type | Exampe |
+| Parameter | Type | Example |
 | --- | --- | --- |
 | *event* | String | `"get"` |
 | *listener* | Function | |

--- a/doc/api/event/global_on.md
+++ b/doc/api/event/global_on.md
@@ -2,7 +2,7 @@
 
 Add a listener function to the specified event globally (for all instances).
 
-| Parameter | Type | Exampe |
+| Parameter | Type | Example |
 | --- | --- | --- |
 | *event* | String | `"get"` |
 | *listener* | Function | |

--- a/doc/api/event/global_once.md
+++ b/doc/api/event/global_once.md
@@ -2,7 +2,7 @@
 
 Add a listener function to the specified event globally (for all instances). It will be automatically removed after it's first execution.
 
-| Parameter | Type | Exampe |
+| Parameter | Type | Example |
 | --- | --- | --- |
 | *event* | String | `"get"` |
 | *listener* | Function | |

--- a/doc/api/event/off.md
+++ b/doc/api/event/off.md
@@ -2,7 +2,7 @@
 
 Removes a listener function from the specified event for this instance.
 
-| Parameter | Type | Exampe |
+| Parameter | Type | Example |
 | --- | --- | --- |
 | *event* | String | `"get"` |
 | *listener* | Function | |

--- a/doc/api/event/on.md
+++ b/doc/api/event/on.md
@@ -2,7 +2,7 @@
 
 Add a listener function to the specified event for this instance.
 
-| Parameter | Type | Exampe |
+| Parameter | Type | Example |
 | --- | --- | --- |
 | *event* | String | `"get"` |
 | *listener* | Function | |

--- a/doc/api/event/once.md
+++ b/doc/api/event/once.md
@@ -2,7 +2,7 @@
 
 Add a listener function to the specified event for this instance. It will be automatically removed after it's first execution.
 
-| Parameter | Type | Exampe |
+| Parameter | Type | Example |
 | --- | --- | --- |
 | *event* | String | `"get"` |
 | *listener* | Function | |

--- a/doc/api/supplemental.md
+++ b/doc/api/supplemental.md
@@ -2,7 +2,7 @@
 
 It's an alias for `.get([ "supplemental", ... ])`.
 
-| Parameter | Type | Exampe |
+| Parameter | Type | Example |
 | --- | --- | --- |
 | *path* | String or<br>Array | See `cldr.get()` for more information |
 

--- a/doc/api/unresolved/get.md
+++ b/doc/api/unresolved/get.md
@@ -2,7 +2,7 @@
 
 Overload (extend) `.get()` to get the item data or lookup by following [locale inheritance](http://www.unicode.org/reports/tr35/#Locale_Inheritance), set a local resolved cache if it's found (for subsequent faster access), or return `undefined`.
 
-| Parameter | Type | Exampe |
+| Parameter | Type | Example |
 | --- | --- | --- |
 | *path* | String or<br>Array | See `cldr.get()` above for more information |
 


### PR DESCRIPTION
Signed-off-by: Raman But-Husaim <raman_buthusaim@yahoo.com>