### PR TITLE
Fix bug where bundleMapQueue is not cleared after an error

### DIFF
--- a/src/bundle/lookup.js
+++ b/src/bundle/lookup.js
@@ -17,6 +17,7 @@ export default function(Cldr, cldr, minLanguageId) {
     availableBundleMapQueue = Cldr._availableBundleMapQueue;
 
   if (availableBundleMapQueue.length) {
+    Cldr._availableBundleMapQueue = [];
     arrayForEach(availableBundleMapQueue, function(bundle) {
       var existing, maxBundle, minBundle, subtags;
       subtags = coreSubtags(bundle);
@@ -29,7 +30,6 @@ export default function(Cldr, cldr, minLanguageId) {
       }
       availableBundleMap[minBundle] = bundle;
     });
-    Cldr._availableBundleMapQueue = [];
   }
 
   return availableBundleMap[minLanguageId] || null;

--- a/src/bundle/lookup.js
+++ b/src/bundle/lookup.js
@@ -1,7 +1,6 @@
 import coreLikelySubtags from "../core/likely_subtags";
 import coreRemoveLikelySubtags from "../core/remove_likely_subtags";
 import coreSubtags from "../core/subtags";
-import arrayForEach from "../util/array/for_each";
 
 /**
  * bundleLookup( minLanguageId )
@@ -17,11 +16,19 @@ export default function(Cldr, cldr, minLanguageId) {
     availableBundleMapQueue = Cldr._availableBundleMapQueue;
 
   if (availableBundleMapQueue.length) {
-    Cldr._availableBundleMapQueue = [];
-    arrayForEach(availableBundleMapQueue, function(bundle) {
+    while (availableBundleMapQueue.length > 0) {
+      const bundle = availableBundleMapQueue.shift();
+      if (!bundle) {
+        break;
+      }
+
       var existing, maxBundle, minBundle, subtags;
       subtags = coreSubtags(bundle);
       maxBundle = coreLikelySubtags(Cldr, cldr, subtags);
+      if (typeof maxBundle === "undefined") {
+        throw new Error(`Could not find likelySubtags for ${bundle}`);
+      }
+
       minBundle = coreRemoveLikelySubtags(Cldr, cldr, maxBundle);
       minBundle = minBundle.join(Cldr.localeSep);
       existing = availableBundleMap[minBundle];
@@ -29,7 +36,7 @@ export default function(Cldr, cldr, minLanguageId) {
         return;
       }
       availableBundleMap[minBundle] = bundle;
-    });
+    }
   }
 
   return availableBundleMap[minLanguageId] || null;

--- a/test/unit/bundle/lookup.js
+++ b/test/unit/bundle/lookup.js
@@ -56,22 +56,34 @@ describe("Bundle Lookup", function() {
     expect(sr.attributes.bundle).to.equal("sr");
   });
 
-  it("should clear the global _availableBundleMapQueue on failure to process bundle", function() {
-    expect(() => {
-      Cldr.load({
-        main: { "xx-XX": {} }
-      });
-      expect(Cldr._availableBundleMapQueue).to.include.members(["xx-XX"]);
-      new Cldr("xx-XX");
-    }).to.throw();
-    expect(Cldr._availableBundleMapQueue).to.be.empty;
+  it("should remove problematic bundle from the global _availableBundleMapQueue on failure", function() {
+    Cldr.load(
+      {
+        main: { bg: {} } // valid
+      },
+      {
+        main: { xx: {} } // invalid
+      },
+      {
+        main: { sr: {} } // valid
+      }
+    );
 
-    Cldr.load({
-      main: { sr: {} }
-    });
-    expect(Cldr._availableBundleMapQueue).to.include.members(["sr"]);
-    const sr = new Cldr("sr-Cyrl");
-    expect(Cldr._availableBundleMapQueue).to.be.empty;
-    expect(sr.attributes.bundle).to.equal("sr");
+    expect(Cldr._availableBundleMapQueue).to.eql(["bg", "xx", "sr"]);
+
+    expect(() => {
+      // triggers the loading of bundle queue
+      new Cldr("bg");
+    }).to.throw();
+
+    expect(Cldr._availableBundleMapQueue).to.eql(["sr"]);
+
+    // the invalid bundle has been removed so we can load bg
+    new Cldr("bg");
+
+    // and sr, which will now trigger the loading of the rest of the queue
+    new Cldr("sr");
+
+    expect(Cldr._availableBundleMapQueue).to.eql([]);
   });
 });

--- a/test/unit/bundle/lookup.js
+++ b/test/unit/bundle/lookup.js
@@ -63,11 +63,11 @@ describe("Bundle Lookup", function() {
       });
       expect(Cldr._availableBundleMapQueue).to.include.members(["xx-XX"]);
       new Cldr("xx-XX");
-    }).to.throw()
+    }).to.throw();
     expect(Cldr._availableBundleMapQueue).to.be.empty;
 
     Cldr.load({
-      main: { "sr": {} }
+      main: { sr: {} }
     });
     expect(Cldr._availableBundleMapQueue).to.include.members(["sr"]);
     const sr = new Cldr("sr-Cyrl");

--- a/test/unit/bundle/lookup.js
+++ b/test/unit/bundle/lookup.js
@@ -55,4 +55,23 @@ describe("Bundle Lookup", function() {
     sr = new Cldr("sr-RS");
     expect(sr.attributes.bundle).to.equal("sr");
   });
+
+  it("should clear the global _availableBundleMapQueue on failure to process bundle", function() {
+    expect(() => {
+      Cldr.load({
+        main: { "xx-XX": {} }
+      });
+      expect(Cldr._availableBundleMapQueue).to.include.members(["xx-XX"]);
+      new Cldr("xx-XX");
+    }).to.throw()
+    expect(Cldr._availableBundleMapQueue).to.be.empty;
+
+    Cldr.load({
+      main: { "sr": {} }
+    });
+    expect(Cldr._availableBundleMapQueue).to.include.members(["sr"]);
+    const sr = new Cldr("sr-Cyrl");
+    expect(Cldr._availableBundleMapQueue).to.be.empty;
+    expect(sr.attributes.bundle).to.equal("sr");
+  });
 });


### PR DESCRIPTION
Fixes #69 

# What happened
At the Localisation & Globalisation team at my company, we've decided to release an internal "test" locale (we called it xx-XX) to provide pseudo localisation for all other teams across. Since this locale is fictional there is no CLDR data for it. Our approach was to take es-ES and alter the data so that it acts as the new xx-XX locale.

During the process we've missed the likelySubtags object, meaning there was a mismatch
```
"main": {
  "xx-XX": {...}
},
"supplemental": {
  "likelySubtags": {
    "und": "es",
    "es-ES": "es"
  }
}
```

# The error
Passing this data into a `Globalize.load()` (which in turn calls `CLDR.load()`) causes no errors, however, instantiating a new instance `new Globalize(locale)` throws `TypeError: Cannot read property '0' of undefined`. Note that what `locale` is above doesn't matter. Locales with already loaded valid data can no longer be used.

# Expected outcome
An error to be thrown *only once* and the data is ejected from the queue to allow the application to continue without a need to restart.

# Impact
The service that observed the error is using Globalize in its backend. This means that after an internal user (xx-XX is only an internal locale, no end-user can request it) tested the new locale end-users using actual locales started seeing errors due to the recurring exception thrown for valid locales.

# Why this fixed it
I have moved the clearing of the _availableBundleMapQueue to before the iteration over it. That way even if there is an error in the code below the error will happen only once. There appear to be no other exit points before the queue clearing, so pulling it earlier is not changing the behaviour.
